### PR TITLE
Add support for PL/pgSQL parsing.

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -37,6 +37,26 @@ func ParseToJSON(input string) (result string, err error) {
 	return
 }
 
+// ParsePlPgSqlToJSON - Parses the given PL/pgSQL function statement into an AST (JSON format)
+func ParsePlPgSqlToJSON(input string) (result string, err error) {
+	inputC := C.CString(input)
+	defer C.free(unsafe.Pointer(inputC))
+
+	resultC := C.pg_query_parse_plpgsql(inputC)
+
+	defer C.pg_query_free_plpgsql_parse_result(resultC)
+
+	if resultC.error != nil {
+		errMessage := C.GoString(resultC.error.message)
+		err = errors.New(errMessage)
+		return
+	}
+
+	result = C.GoString(resultC.plpgsql_funcs)
+
+	return
+}
+
 // Normalize the passed SQL statement to replace constant values with ? characters
 func Normalize(input string) (result string, err error) {
 	inputC := C.CString(input)

--- a/pg_query.go
+++ b/pg_query.go
@@ -33,6 +33,11 @@ func Parse(input string) (tree ParsetreeList, err error) {
 	return
 }
 
+// ParsePlPgSqlToJSON - Parses the given PL/pgSQL function statement into an AST (JSON format)
+func ParsePlPgSqlToJSON(input string) (result string, err error) {
+	return parser.ParsePlPgSqlToJSON(input)
+}
+
 // Normalize the passed SQL statement to replace constant values with ? characters
 func Normalize(input string) (result string, err error) {
 	return parser.Normalize(input)


### PR DESCRIPTION
I added support for PL/pgSQL parsing to JSON. Sadly, the unmarshalling to Go structs does not even work for the [example](https://github.com/lfittl/libpg_query#usage-parsing-a-plpgsql-function-experimental), hence I did not add it.

Fix #6.