### PR TITLE
Move -fstack-protector into CFLAGS.

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,8 +1,8 @@
 package parser
 
 /*
-#cgo CFLAGS: -Iinclude -g
-#cgo LDFLAGS: -fstack-protector
+#cgo CFLAGS: -Iinclude -g -fstack-protector
+#cgo LDFLAGS:
 #include "pg_query.h"
 #include <stdlib.h>
 */


### PR DESCRIPTION
LDFLAGS looks wrong, since it's a program instrumentation option
understood by the compiler.

The current behavior fails for example in Fedora 27, moving into CFLAGS fixes
the problem.