### PR TITLE
Silence compiler "warning" about ignored return values.

### DIFF
--- a/parser/pg_query_parse_plpgsql.c
+++ b/parser/pg_query_parse_plpgsql.c
@@ -430,11 +430,12 @@ PgQueryPlpgsqlParseResult pg_query_parse_plpgsql(const char* input)
 		if (func_and_error.func != NULL) {
 			char *func_json;
 			char *new_out;
+			int ignored;
 
 			func_json = plpgsqlToJSON(func_and_error.func);
 			plpgsql_free_function_memory(func_and_error.func);
 
-			asprintf(&new_out, "%s%s,\n", result.plpgsql_funcs, func_json);
+			ignored = asprintf(&new_out, "%s%s,\n", result.plpgsql_funcs, func_json);
 			free(result.plpgsql_funcs);
 			result.plpgsql_funcs = new_out;
 


### PR DESCRIPTION
A hackity hack that lets me use pg_query_go in golang 1.10. Otherwise, the compiler "warning" is more like a fatal.