### PR TITLE
Replace fstack-protector with more performant fstack-protector-strong

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -1,7 +1,7 @@
 package parser
 
 /*
-#cgo CFLAGS: -Iinclude -g -fstack-protector
+#cgo CFLAGS: -Iinclude -g -fstack-protector-strong
 #cgo LDFLAGS:
 #include "pg_query.h"
 #include <stdlib.h>


### PR DESCRIPTION
I've noticed that you are using `fstack-protector` which could be substituted by `fstack-protector-strong` which is a [more improved version](https://gcc.gnu.org/ml/gcc-patches/2012-06/msg00974.html) without the need to go the whole way to `all`.

It was added to gcc 4.9 released in [April 2014](https://www.gnu.org/software/gcc/gcc-4.9/) so it should be safe to assume that it's now widely supported.