### PR TITLE
Update Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: go
 
 go:
-  - 1.5
-  - 1.6
-  - tip
+  - 1.12.x
+  - master
+
+go_import_path: github.com/lfittl/pg_query_go


### PR DESCRIPTION
* Bump Go versions
* Set `go_import_path` explicitly to allow forks to use Travis CI